### PR TITLE
remove getting highlight key from search hits

### DIFF
--- a/service/ESService.java
+++ b/service/ESService.java
@@ -427,7 +427,7 @@ public class ESService {
                 for (String[] highlight: highlights) {
                     String hlName = highlight[0];
                     String hlField = highlight[1];
-                    JsonElement element = searchHits.get(i).getAsJsonObject().get("highlight").getAsJsonObject().get(hlField);
+                    JsonElement element = searchHits.get(i).getAsJsonObject().get(hlField);
                     if (element != null) {
                         row.put(hlName, ((List<String>)getValue(element)).get(0));
                     }


### PR DESCRIPTION
- attempting to get the `highlight` key from `searchHits` JSON data from `model_properties` index results in a global search error when searching for terms like "case id" (resulting in a blank page on FE because query returns null)