### PR TITLE
Revert page size env var

### DIFF
--- a/model/ConfigurationDAO.java
+++ b/model/ConfigurationDAO.java
@@ -84,7 +84,7 @@ public class ConfigurationDAO {
 	private String region;
 
 	// Recommended maximum page size
-	@Value("${page_size:10000}")
+	@Value("${page_size:5000}")
 	private int pageSize;
 
 	//Testing

--- a/model/ConfigurationDAO.java
+++ b/model/ConfigurationDAO.java
@@ -83,10 +83,6 @@ public class ConfigurationDAO {
 	@Value("${es.region}")
 	private String region;
 
-	// Recommended maximum page size
-	@Value("${page_size:5000}")
-	private int pageSize;
-
 	//Testing
 	@Value("${test.queries_file}")
 	private String testQueriesFile;

--- a/model/ConfigurationDAO.java
+++ b/model/ConfigurationDAO.java
@@ -84,7 +84,7 @@ public class ConfigurationDAO {
 	private String region;
 
 	// Recommended maximum page size
-	@Value("${page_size}")
+	@Value("${page_size:10000}")
 	private int pageSize;
 
 	//Testing


### PR DESCRIPTION
ConfigurationDAO is used for the Opensearch service. The env var we want is not used by the Opensearch service, so we removed it from here. It will be called by C3DC code.