### PR TITLE
Fix fragment size assignment in highlight builder

### DIFF
--- a/model/search/filter/GlobalQueryFilter.java
+++ b/model/search/filter/GlobalQueryFilter.java
@@ -124,7 +124,7 @@ public class GlobalQueryFilter {
             yamlHighlight.getFields().forEach(highlightBuilder::field);
             highlightBuilder.preTags(yamlHighlight.getPreTag() == null ? "" : yamlHighlight.getPreTag());
             highlightBuilder.postTags(yamlHighlight.getPostTag() == null ? "" : yamlHighlight.getPostTag());
-            if (highlightBuilder.fragmentSize() != null) highlightBuilder.fragmentSize(yamlHighlight.getFragmentSize());
+            if (highlightBuilder.fragmentSize(yamlHighlight.getFragmentSize()) != null) highlightBuilder.fragmentSize(yamlHighlight.getFragmentSize());
             builder.highlighter(highlightBuilder);
         }
     }


### PR DESCRIPTION
Corrects the conditional logic for setting fragment size in the highlight builder by passing the value from yamlHighlight. Ensures fragment size is set only when appropriate.

CTDC Tickets : 
https://tracker.nci.nih.gov/browse/CTDC-1596 ,
https://tracker.nci.nih.gov/browse/CTDC-1514
CTDC PR:
https://github.com/CBIIT/crdc-ctdc-backend/pull/98/files


